### PR TITLE
java: Improve bnechmark using BufferedReader

### DIFF
--- a/src/codegen/java.rs
+++ b/src/codegen/java.rs
@@ -4,7 +4,7 @@ pub struct Java;
 impl Lang for Java {
     fn read_line(bind: Bind) -> (Code, Index) {
         let mut code = vec![];
-        code.push(format!("var {bind} = input.nextLine().split(\" \");"));
+        code.push(format!("var {bind} = input.readLine().split(\" \");"));
         let n = new_var();
         code.push(format!("var {n} = {bind}.length;"));
         (code, Index(n.0))

--- a/test-runner/data/lang/java/template
+++ b/test-runner/data/lang/java/template
@@ -1,11 +1,13 @@
 import java.util.*;
+import java.io.*;
 
 public class Main \{
-    public static void main(String[] args) \{
-		Scanner input = new Scanner(System.in);
+    public static void main(String[] args) throws IOException \{
+        var input = new BufferedReader(new InputStreamReader(System.in));
 
 { parser }
 
 { checker }
+
 	}
 }


### PR DESCRIPTION
Here is a significant improvement and competitors should use `BufferedReader` to avoid unwanted TLE.

Most competitors now use `Scanner` to utilize `nextInt` or so. But this manner is known slow. With Procon Input, competitors can parse the input faster than ever.

before (`Scanner#nextLine`):
```
java-1: 225.300588ms
java-2: 366.386464ms
java-3: 145.577173ms
```

after (`BufferedReader#readLine`):
```
java-1: 142.859143ms
java-2: 166.40148ms
java-3: 103.147926ms
```