### PR TITLE
C++: Use atoi instead of sscanf for more performance

### DIFF
--- a/src/codegen/cpp.rs
+++ b/src/codegen/cpp.rs
@@ -114,14 +114,14 @@ fn scan_unit_type(bind: Bind, ast: &ast::UnitType, s: &str) -> Code {
     code.push(format!("{ty} {bind};"));
     match ast {
         ast::UnitType::Int => {
-            code.push(format!("sscanf({s}.c_str(), \"%d\", &{bind});"));
+            code.push(format!("{bind} = atoi({s}.c_str());"));
         }
         ast::UnitType::Int0 => {
-            code.push(format!("sscanf({s}.c_str(), \"%d\", &{bind});"));
+            code.push(format!("{bind} = atoi({s}.c_str());"));
             code.push(format!("{bind}--;"));
         }
         ast::UnitType::Float => {
-            code.push(format!("sscanf({s}.c_str(), \"%f\", &{bind});"));
+            code.push(format!("{bind} = atof({s}.c_str());"));
         }
         ast::UnitType::Str => {
             code.push(format!("{bind} = {s};"));


### PR DESCRIPTION
`atoi` performs better than `sscanf`.

before: 

https://github.com/akiradeveloper/procon-input-compiler/pull/37

after:

| bench_no | python | cpp | nim | ruby | java | csharp | rust |
|----------|--------|-----|-----|------|------|--------|------|
| 1        | 0      | 17  | 0   | 0    | 0    | 0      | 0    |
| 2        | 0      | 68  | 0   | 0    | 0    | 0      | 0    |
| 3        | 0      | 5   | 0   | 0    | 0    | 0      | 0    |

I think remaining issue is use of `istringstream` to split the line. 